### PR TITLE
archivos de electricCarData limpios y gurdados

### DIFF
--- a/Datasets_clean/ElectricCarData_Clean.csv
+++ b/Datasets_clean/ElectricCarData_Clean.csv
@@ -1,0 +1,104 @@
+Brand,Model,AccelSec,TopSpeed_KmH,Range_Km,Efficiency_WhKm,FastCharge_KmH,RapidCharge,PowerTrain,PlugType,BodyStyle,Segment,Seats,PriceEuro
+Tesla ,Model 3 Long Range Dual Motor,4.6,233,450,161,940,Yes,AWD,Type 2 CCS,Sedan,D,5,55480
+Volkswagen ,ID.3 Pure,10.0,160,270,167,250,Yes,RWD,Type 2 CCS,Hatchback,C,5,30000
+Polestar ,2,4.7,210,400,181,620,Yes,AWD,Type 2 CCS,Liftback,D,5,56440
+BMW ,iX3 ,6.8,180,360,206,560,Yes,RWD,Type 2 CCS,SUV,D,5,68040
+Honda ,e ,9.5,145,170,168,190,Yes,RWD,Type 2 CCS,Hatchback,B,4,32997
+Lucid ,Air ,2.8,250,610,180,620,Yes,AWD,Type 2 CCS,Sedan,F,5,105000
+Volkswagen ,e-Golf ,9.6,150,190,168,220,Yes,FWD,Type 2 CCS,Hatchback,C,5,31900
+Peugeot ,e-208 ,8.1,150,275,164,420,Yes,FWD,Type 2 CCS,Hatchback,B,5,29682
+Tesla ,Model 3 Standard Range Plus,5.6,225,310,153,650,Yes,RWD,Type 2 CCS,Sedan,D,5,46380
+Audi ,Q4 e-tron ,6.3,180,400,193,540,Yes,AWD,Type 2 CCS,SUV,D,5,55000
+Mercedes ,EQC 400 4MATIC,5.1,180,370,216,440,Yes,AWD,Type 2 CCS,SUV,D,5,69484
+Nissan ,Leaf ,7.9,144,220,164,230,Yes,FWD,Type 2 CHAdeMO,Hatchback,C,5,29234
+Hyundai ,Kona Electric 64 kWh,7.9,167,400,160,380,Yes,FWD,Type 2 CCS,SUV,B,5,40795
+BMW ,i4 ,4.0,200,450,178,650,Yes,RWD,Type 2 CCS,Sedan,D,5,65000
+Hyundai ,IONIQ Electric,9.7,165,250,153,210,Yes,FWD,Type 2 CCS,Liftback,C,5,34459
+Volkswagen ,ID.3 Pro S,7.9,160,440,175,590,Yes,RWD,Type 2 CCS,Hatchback,C,4,40936
+Porsche ,Taycan Turbo S,2.8,260,375,223,780,Yes,AWD,Type 2 CCS,Sedan,F,4,180781
+Volkswagen ,e-Up! ,11.9,130,195,166,170,Yes,FWD,Type 2 CCS,Hatchback,A,4,21421
+MG ,ZS EV,8.2,140,220,193,260,Yes,FWD,Type 2 CCS,SUV,B,5,30000
+Mini ,Cooper SE ,7.3,150,185,156,260,Yes,FWD,Type 2 CCS,Hatchback,B,4,31681
+Opel ,Corsa-e ,8.1,150,275,164,420,Yes,FWD,Type 2 CCS,Hatchback,B,5,29146
+Tesla ,Model Y Long Range Dual Motor,5.1,217,425,171,930,Yes,AWD,Type 2 CCS,SUV,D,7,58620
+Skoda ,Enyaq iV 50,10.0,160,290,179,230,Yes,RWD,Type 2 CCS,SUV,C,5,35000
+Audi ,e-tron GT ,3.5,240,425,197,850,Yes,AWD,Type 2 CCS,Sedan,F,4,125000
+Tesla ,Model 3 Long Range Performance,3.4,261,435,167,910,Yes,AWD,Type 2 CCS,Sedan,D,5,61480
+Volkswagen ,ID.4 ,7.5,160,420,183,560,Yes,RWD,Type 2 CCS,SUV,C,5,45000
+Volkswagen ,ID.3 Pro,9.0,160,350,166,490,Yes,RWD,Type 2 CCS,Hatchback,C,5,33000
+Volvo ,XC40 P8 AWD Recharge,4.9,180,375,200,470,Yes,AWD,Type 2 CCS,SUV,C,5,60437
+BMW ,i3 120 Ah,7.3,150,235,161,270,Yes,RWD,Type 2 CCS,Hatchback,B,4,38017
+Peugeot ,e-2008 SUV ,8.5,150,250,180,380,Yes,FWD,Type 2 CCS,SUV,B,5,34361
+Audi ,e-tron 50 quattro,6.8,190,280,231,450,Yes,AWD,Type 2 CCS,SUV,E,5,67358
+Kia ,e-Niro 64 kWh,7.8,167,370,173,350,Yes,FWD,Type 2 CCS,SUV,C,5,38105
+Renault ,Zoe ZE50 R110,11.4,135,315,165,230,Yes,FWD,Type 2 CCS,Hatchback,B,5,31184
+Tesla ,Cybertruck Tri Motor,3.0,210,750,267,710,Yes,AWD,Type 2 CCS,Pickup,N,6,75000
+Mazda ,MX-30 ,9.0,150,180,178,240,Yes,FWD,Type 2 CCS,SUV,C,5,32646
+Nissan ,Leaf e+,7.3,157,325,172,390,Yes,FWD,Type 2 CHAdeMO,Hatchback,C,5,37237
+Lexus ,UX 300e,7.5,160,270,193,190,Yes,FWD,Type 2 CHAdeMO,SUV,C,5,50000
+CUPRA ,el-Born ,6.5,160,425,181,570,Yes,RWD,Type 2 CCS,Hatchback,C,4,45000
+Renault ,Zoe ZE50 R135,9.5,140,310,168,230,Yes,FWD,Type 2 CCS,Hatchback,B,5,33133
+Mercedes ,EQA ,5.0,200,350,171,440,Yes,AWD,Type 2 CCS,SUV,C,5,45000
+Tesla ,Model S Long Range,3.8,250,515,184,560,Yes,AWD,Type 2,Liftback,F,5,79990
+Hyundai ,Kona Electric 39 kWh,9.9,155,255,154,210,Yes,FWD,Type 2 CCS,SUV,B,5,33971
+Audi ,e-tron Sportback 55 quattro,5.7,200,380,228,610,Yes,AWD,Type 2 CCS,SUV,E,5,81639
+Skoda ,CITIGOe iV ,12.3,130,195,166,170,Yes,FWD,Type 2 CCS,Hatchback,A,4,24534
+SEAT ,Mii Electric ,12.3,130,195,166,170,Yes,FWD,Type 2 CCS,Hatchback,A,4,20129
+Kia ,e-Soul 64 kWh,7.9,167,365,175,340,Yes,FWD,Type 2 CCS,SUV,B,5,36837
+Opel ,Ampera-e ,7.3,150,335,173,210,Yes,FWD,Type 2 CCS,MPV,B,5,41906
+Porsche ,Taycan 4S,4.0,250,365,195,730,Yes,AWD,Type 2 CCS,Sedan,F,4,102945
+Lightyear ,One ,10.0,150,575,104,540,Yes,AWD,Type 2 CCS,Liftback,F,5,149000
+Aiways ,U5 ,9.0,150,335,188,350,Yes,FWD,Type 2 CCS,SUV,C,5,36057
+Audi ,e-tron 55 quattro,5.7,200,365,237,590,Yes,AWD,Type 2 CCS,SUV,E,5,79445
+Tesla ,Roadster ,2.1,410,970,206,920,Yes,AWD,Type 2 CCS,Cabrio,S,4,215000
+Opel ,Mokka-e ,8.5,150,255,176,390,Yes,FWD,Type 2 CCS,SUV,B,5,35000
+Skoda ,Enyaq iV 80,8.8,160,420,183,560,Yes,RWD,Type 2 CCS,SUV,C,5,40000
+Tesla ,Model X Long Range,4.6,250,450,211,490,Yes,AWD,Type 2,SUV,F,7,85990
+Honda ,e Advance,8.3,145,170,168,190,Yes,RWD,Type 2 CCS,Hatchback,B,4,35921
+DS ,3 Crossback E-Tense,8.7,150,250,180,380,Yes,FWD,Type 2 CCS,SUV,B,5,37422
+0,0,0.0,0,0,0,0,0,0,0,0,0,0,0
+Citroen ,e-C4 ,9.7,150,250,180,380,Yes,FWD,Type 2 CCS,SUV,C,5,40000
+Tesla ,Model S Performance,2.5,261,505,188,550,Yes,AWD,Type 2,Liftback,F,5,96990
+Renault ,Zoe ZE40 R110,11.4,135,255,161,230,Yes,FWD,Type 2 CCS,Hatchback,B,5,29234
+Tesla ,Model Y Long Range Performance,3.7,241,410,177,900,Yes,AWD,Type 2 CCS,SUV,D,7,65620
+Nissan ,Ariya 87kWh,7.6,160,440,198,520,Yes,FWD,Type 2 CCS,Hatchback,C,5,50000
+Jaguar ,I-Pace ,4.8,200,365,232,340,Yes,AWD,Type 2 CCS,SUV,E,5,75351
+Ford ,Mustang Mach-E ER RWD,7.0,180,450,200,430,Yes,RWD,Type 2 CCS,SUV,D,5,54475
+Porsche ,Taycan 4S Plus,4.0,250,425,197,890,Yes,AWD,Type 2 CCS,Sedan,F,4,109302
+Nissan ,e-NV200 Evalia ,14.0,123,190,200,190,Yes,FWD,Type 1 CHAdeMO,SPV,N,7,33246
+Tesla ,Cybertruck Dual Motor,5.0,190,460,261,710,Yes,AWD,Type 2 CCS,Pickup,N,6,55000
+0,0,0.0,0,0,0,0,0,0,0,0,0,0,0
+Ford ,Mustang Mach-E ER AWD,6.0,180,430,209,410,Yes,AWD,Type 2 CCS,SUV,D,5,62900
+BMW ,i3s 120 Ah,6.9,160,230,165,260,Yes,RWD,Type 2 CCS,Hatchback,B,4,41526
+Skoda ,Enyaq iV 80X,7.0,160,400,193,540,Yes,AWD,Type 2 CCS,SUV,C,5,45000
+Porsche ,Taycan Cross Turismo ,3.5,250,385,217,770,Yes,AWD,Type 2 CCS,Station,F,4,150000
+Byton ,M-Byte 95 kWh 4WD,5.5,190,390,244,460,Yes,AWD,Type 2 CCS,SUV,E,5,64000
+Sono ,Sion ,9.0,140,225,156,270,Yes,FWD,Type 2 CCS,Hatchback,C,5,25500
+Kia ,e-Niro 39 kWh,9.8,155,235,167,230,Yes,FWD,Type 2 CCS,SUV,C,5,34400
+Audi ,Q4 Sportback e-tron ,6.3,180,410,188,550,Yes,AWD,Type 2 CCS,SUV,D,5,57500
+0,0,0.0,0,0,0,0,0,0,0,0,0,0,0
+Ford ,Mustang Mach-E SR AWD,6.0,180,340,206,360,Yes,AWD,Type 2 CCS,SUV,D,5,54000
+Porsche ,Taycan Turbo,3.2,260,390,215,810,Yes,AWD,Type 2 CCS,Sedan,F,4,148301
+Volkswagen ,ID.3 1st,7.3,160,340,171,470,Yes,RWD,Type 2 CCS,Hatchback,C,5,38987
+Tesla ,Model X Performance,2.8,250,440,216,480,Yes,AWD,Type 2,SUV,F,7,102990
+0,0,0.0,0,0,0,0,0,0,0,0,0,0,0
+Ford ,Mustang Mach-E SR RWD,6.6,180,360,194,380,Yes,RWD,Type 2 CCS,SUV,D,5,46900
+Mercedes ,EQV 300 Long,10.0,140,330,273,290,Yes,FWD,Type 2 CCS,SPV,N,7,70631
+Fiat ,500e Hatchback,9.0,150,250,168,330,Yes,FWD,Type 2 CCS,Hatchback,B,4,34900
+Tesla ,Cybertruck Single Motor,7.0,180,390,256,740,Yes,RWD,Type 2 CCS,Pickup,N,6,45000
+Audi ,e-tron Sportback 50 quattro,6.8,190,295,219,470,Yes,AWD,Type 2 CCS,SUV,E,5,69551
+Skoda ,Enyaq iV vRS,6.2,180,400,193,540,Yes,AWD,Type 2 CCS,SUV,C,5,47500
+Skoda ,Enyaq iV 60,9.0,160,320,181,440,Yes,RWD,Type 2 CCS,SUV,C,5,37500
+Audi ,e-tron S 55 quattro,4.5,210,320,270,510,Yes,AWD,Type 2 CCS,SUV,E,5,93800
+0,0,0.0,0,0,0,0,0,0,0,0,0,0,0
+Kia ,e-Soul 64 kWh,7.9,167,365,175,320,Yes,FWD,Type 2 CCS,SUV,B,5,36837
+Nissan ,Ariya e-4ORCE 87kWh,5.7,200,420,207,500,Yes,AWD,Type 2 CCS,Hatchback,C,5,57500
+Fiat ,500e Convertible,9.0,150,250,168,330,Yes,FWD,Type 2 CCS,Cabrio,B,4,37900
+Volkswagen ,ID.3 Pro Performance,7.3,160,340,171,470,Yes,RWD,Type 2 CCS,Hatchback,C,5,35575
+Kia ,e-Soul 39 kWh,9.9,157,230,170,220,Yes,FWD,Type 2 CCS,SUV,B,5,33133
+Byton ,M-Byte 72 kWh 2WD,7.5,190,325,222,420,Yes,RWD,Type 2 CCS,SUV,E,5,53500
+Nissan ,Ariya 63kWh,7.5,160,330,191,440,Yes,FWD,Type 2 CCS,Hatchback,C,5,45000
+Audi ,e-tron S Sportback 55 quattro,4.5,210,335,258,540,Yes,AWD,Type 2 CCS,SUV,E,5,96050
+Nissan ,Ariya e-4ORCE 63kWh,5.9,200,325,194,440,Yes,AWD,Type 2 CCS,Hatchback,C,5,50000
+Nissan ,Ariya e-4ORCE 87kWh Performance,5.1,200,375,232,450,Yes,AWD,Type 2 CCS,Hatchback,C,5,65000
+Byton ,M-Byte 95 kWh 2WD,7.5,190,400,238,480,Yes,AWD,Type 2 CCS,SUV,E,5,62000

--- a/ETL_gaston.ipynb
+++ b/ETL_gaston.ipynb
@@ -947,12 +947,204 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### ETL Inicial, archivo: **ElectricCarData_Norm.csv**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'ElectricCarData_Norm.csv'"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "dict_files['df4']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Brand</th>\n",
+       "      <th>Model</th>\n",
+       "      <th>Accel</th>\n",
+       "      <th>TopSpeed</th>\n",
+       "      <th>Range</th>\n",
+       "      <th>Efficiency</th>\n",
+       "      <th>FastCharge</th>\n",
+       "      <th>RapidCharge</th>\n",
+       "      <th>PowerTrain</th>\n",
+       "      <th>PlugType</th>\n",
+       "      <th>BodyStyle</th>\n",
+       "      <th>Segment</th>\n",
+       "      <th>Seats</th>\n",
+       "      <th>PriceEuro</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>Tesla</td>\n",
+       "      <td>Model 3 Long Range Dual Motor</td>\n",
+       "      <td>4.6 sec</td>\n",
+       "      <td>233 km/h</td>\n",
+       "      <td>450 km</td>\n",
+       "      <td>161 Wh/km</td>\n",
+       "      <td>940 km/h</td>\n",
+       "      <td>Rapid charging possible</td>\n",
+       "      <td>All Wheel Drive</td>\n",
+       "      <td>Type 2 CCS</td>\n",
+       "      <td>Sedan</td>\n",
+       "      <td>D</td>\n",
+       "      <td>5</td>\n",
+       "      <td>55480</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>Volkswagen</td>\n",
+       "      <td>ID.3 Pure</td>\n",
+       "      <td>10.0 sec</td>\n",
+       "      <td>160 km/h</td>\n",
+       "      <td>270 km</td>\n",
+       "      <td>167 Wh/km</td>\n",
+       "      <td>250 km/h</td>\n",
+       "      <td>Rapid charging possible</td>\n",
+       "      <td>Rear Wheel Drive</td>\n",
+       "      <td>Type 2 CCS</td>\n",
+       "      <td>Hatchback</td>\n",
+       "      <td>C</td>\n",
+       "      <td>5</td>\n",
+       "      <td>30000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>Polestar</td>\n",
+       "      <td>2</td>\n",
+       "      <td>4.7 sec</td>\n",
+       "      <td>210 km/h</td>\n",
+       "      <td>400 km</td>\n",
+       "      <td>181 Wh/km</td>\n",
+       "      <td>620 km/h</td>\n",
+       "      <td>Rapid charging possible</td>\n",
+       "      <td>All Wheel Drive</td>\n",
+       "      <td>Type 2 CCS</td>\n",
+       "      <td>Liftback</td>\n",
+       "      <td>D</td>\n",
+       "      <td>5</td>\n",
+       "      <td>56440</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>BMW</td>\n",
+       "      <td>iX3</td>\n",
+       "      <td>6.8 sec</td>\n",
+       "      <td>180 km/h</td>\n",
+       "      <td>360 km</td>\n",
+       "      <td>206 Wh/km</td>\n",
+       "      <td>560 km/h</td>\n",
+       "      <td>Rapid charging possible</td>\n",
+       "      <td>Rear Wheel Drive</td>\n",
+       "      <td>Type 2 CCS</td>\n",
+       "      <td>SUV</td>\n",
+       "      <td>D</td>\n",
+       "      <td>5</td>\n",
+       "      <td>68040</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>Honda</td>\n",
+       "      <td>e</td>\n",
+       "      <td>9.5 sec</td>\n",
+       "      <td>145 km/h</td>\n",
+       "      <td>170 km</td>\n",
+       "      <td>168 Wh/km</td>\n",
+       "      <td>190 km/h</td>\n",
+       "      <td>Rapid charging possible</td>\n",
+       "      <td>Rear Wheel Drive</td>\n",
+       "      <td>Type 2 CCS</td>\n",
+       "      <td>Hatchback</td>\n",
+       "      <td>B</td>\n",
+       "      <td>4</td>\n",
+       "      <td>32997</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "         Brand                          Model     Accel  TopSpeed   Range  \\\n",
+       "0       Tesla   Model 3 Long Range Dual Motor   4.6 sec  233 km/h  450 km   \n",
+       "1  Volkswagen                       ID.3 Pure  10.0 sec  160 km/h  270 km   \n",
+       "2    Polestar                               2   4.7 sec  210 km/h  400 km   \n",
+       "3         BMW                            iX3    6.8 sec  180 km/h  360 km   \n",
+       "4       Honda                              e    9.5 sec  145 km/h  170 km   \n",
+       "\n",
+       "  Efficiency FastCharge              RapidCharge        PowerTrain  \\\n",
+       "0  161 Wh/km   940 km/h  Rapid charging possible   All Wheel Drive   \n",
+       "1  167 Wh/km   250 km/h  Rapid charging possible  Rear Wheel Drive   \n",
+       "2  181 Wh/km   620 km/h  Rapid charging possible   All Wheel Drive   \n",
+       "3  206 Wh/km   560 km/h  Rapid charging possible  Rear Wheel Drive   \n",
+       "4  168 Wh/km   190 km/h  Rapid charging possible  Rear Wheel Drive   \n",
+       "\n",
+       "     PlugType  BodyStyle Segment  Seats  PriceEuro  \n",
+       "0  Type 2 CCS      Sedan       D      5      55480  \n",
+       "1  Type 2 CCS  Hatchback       C      5      30000  \n",
+       "2  Type 2 CCS   Liftback       D      5      56440  \n",
+       "3  Type 2 CCS        SUV       D      5      68040  \n",
+       "4  Type 2 CCS  Hatchback       B      4      32997  "
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df4 = pd.read_csv('./Datasets/' + dict_files['df4'])\n",
+    "df4.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### ETL Inicial, archivo:  **ElectricCarData_Clean.csv**"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 51,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
@@ -961,7 +1153,7 @@
        "'ElectricCarData_Clean.csv'"
       ]
      },
-     "execution_count": 51,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -972,7 +1164,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 52,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -1125,7 +1317,7 @@
        "4  Type 2 CCS  Hatchback       B      4      32997  "
       ]
      },
-     "execution_count": 52,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1137,7 +1329,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 53,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -1174,7 +1366,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 54,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -1188,7 +1380,7 @@
        "       '330', '740', '510', '320', '500'], dtype=object)"
       ]
      },
-     "execution_count": 54,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1198,9 +1390,75 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df3[df3['FastCharge_KmH'] == '-'] = df3[df3['FastCharge_KmH'] == '-'].apply(lambda x: 0) #Reemplazo con 0 los '-', para evitar confictos de tipos de datos en el dw"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df3.FastCharge_KmH = df3.FastCharge_KmH.astype('int64')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<class 'pandas.core.frame.DataFrame'>\n",
+      "RangeIndex: 103 entries, 0 to 102\n",
+      "Data columns (total 14 columns):\n",
+      " #   Column           Non-Null Count  Dtype  \n",
+      "---  ------           --------------  -----  \n",
+      " 0   Brand            103 non-null    object \n",
+      " 1   Model            103 non-null    object \n",
+      " 2   AccelSec         103 non-null    float64\n",
+      " 3   TopSpeed_KmH     103 non-null    int64  \n",
+      " 4   Range_Km         103 non-null    int64  \n",
+      " 5   Efficiency_WhKm  103 non-null    int64  \n",
+      " 6   FastCharge_KmH   103 non-null    int64  \n",
+      " 7   RapidCharge      103 non-null    object \n",
+      " 8   PowerTrain       103 non-null    object \n",
+      " 9   PlugType         103 non-null    object \n",
+      " 10  BodyStyle        103 non-null    object \n",
+      " 11  Segment          103 non-null    object \n",
+      " 12  Seats            103 non-null    int64  \n",
+      " 13  PriceEuro        103 non-null    int64  \n",
+      "dtypes: float64(1), int64(6), object(7)\n",
+      "memory usage: 11.4+ KB\n"
+     ]
+    }
+   ],
+   "source": [
+    "df3.info()"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
-   "source": []
+   "source": [
+    "Se concluye quedarse con este archivo y evitar el uso del normalizado ya que su manipulación será más fácil en pasos posteriores, principalmente porque el otro archivo tiene las unidades agregadas en los campos de las filas, además de que representa los booleanos de manera más difícil de trabajar."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df3.to_csv('./Datasets_clean/' + dict_files['df3'], index=False)"
+   ]
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
Se observo los dos archivos en cuestion electricCarDataClean y Norm, donde se opto por seleccionar el clean, se castearon tipos de datos, se extrajo conclusiones de significados y los valores nulos que figurarban como - en el campo FastCharge_KmH quedaron como 0